### PR TITLE
ST-233: Implement update user via REST API

### DIFF
--- a/src/main/java/com/sergiofreire/xray/tutorials/springboot/boundary/UserRestController.java
+++ b/src/main/java/com/sergiofreire/xray/tutorials/springboot/boundary/UserRestController.java
@@ -42,6 +42,21 @@ public class UserRestController {
         return userService.getAllUsers();
     }
 
+    @PutMapping("/users/{id}")
+    public ResponseEntity<User> updateUser(@PathVariable(value = "id") Long id, 
+                                           @RequestBody User userDetails)
+            throws ResourceNotFoundException {
+        User user = userService.getUserDetails(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found for id: " + id));
+        
+        user.setName(userDetails.getName());
+        user.setUsername(userDetails.getUsername());
+        user.setPassword(userDetails.getPassword());
+        
+        User updatedUser = userService.save(user);
+        return ResponseEntity.ok().body(updatedUser);
+    }
+
     @DeleteMapping("/users/{id}")
     public ResponseEntity<User> deleteUserById(@PathVariable(value = "id") Long id)
             throws ResourceNotFoundException {

--- a/src/test/java/com/sergiofreire/xray/tutorials/springboot/UserRestControllerIT.java
+++ b/src/test/java/com/sergiofreire/xray/tutorials/springboot/UserRestControllerIT.java
@@ -136,6 +136,86 @@ class UserRestControllerIT {
         assertThat(found).hasSize(1);
     }
 
+    @Test
+    @Requirement("ST-233")
+    void updateUserWithSuccess() {
+        User updatedUserData = new User("Sergio Updated", "sergiofreire_updated", "newpassword123");
+        
+        String endpoint = UriComponentsBuilder.newInstance()
+                .scheme("http")
+                .host("127.0.0.1")
+                .port(randomServerPort)
+                .pathSegment("api", "users", user1.getId().toString())
+                .build()
+                .toUriString();
+        
+        ResponseEntity<User> response = restTemplate.exchange(
+                endpoint, 
+                HttpMethod.PUT, 
+                new org.springframework.http.HttpEntity<>(updatedUserData), 
+                User.class);
+        
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getName()).isEqualTo("Sergio Updated");
+        assertThat(response.getBody().getUsername()).isEqualTo("sergiofreire_updated");
+        assertThat(response.getBody().getPassword()).isEqualTo("newpassword123");
+        
+        User userInDb = repository.findById(user1.getId()).orElse(null);
+        assertThat(userInDb).isNotNull();
+        assertThat(userInDb.getName()).isEqualTo("Sergio Updated");
+        assertThat(userInDb.getUsername()).isEqualTo("sergiofreire_updated");
+    }
+
+    @Test
+    @Requirement("ST-233")
+    void updateUserNotFound() {
+        User updatedUserData = new User("Non Existent", "nonexistent", "password123");
+        
+        String endpoint = UriComponentsBuilder.newInstance()
+                .scheme("http")
+                .host("127.0.0.1")
+                .port(randomServerPort)
+                .pathSegment("api", "users", "99999")
+                .build()
+                .toUriString();
+        
+        ResponseEntity<User> response = restTemplate.exchange(
+                endpoint, 
+                HttpMethod.PUT, 
+                new org.springframework.http.HttpEntity<>(updatedUserData), 
+                User.class);
+        
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @Requirement("ST-233")
+    void updateUserWithInvalidData() {
+        User updatedUserData = new User("", "", ""); // Invalid data - all fields blank
+        
+        String endpoint = UriComponentsBuilder.newInstance()
+                .scheme("http")
+                .host("127.0.0.1")
+                .port(randomServerPort)
+                .pathSegment("api", "users", user1.getId().toString())
+                .build()
+                .toUriString();
+        
+        ResponseEntity<User> response = restTemplate.exchange(
+                endpoint, 
+                HttpMethod.PUT, 
+                new org.springframework.http.HttpEntity<>(updatedUserData), 
+                User.class);
+        
+        // Should return error status for invalid data
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        
+        // Verify user was not updated
+        User userInDb = repository.findById(user1.getId()).orElse(null);
+        assertThat(userInDb).isNotNull();
+        assertThat(userInDb.getName()).isEqualTo("Sergio Freire"); // Original name unchanged
+    }
+
     private void createTempUser(String name, String username, String password) {
         User user = new User(name, username, password);
         repository.saveAndFlush(user);


### PR DESCRIPTION
## Description
Implements the ability to update users through the REST API as specified in requirement ST-233.

## Changes
- Added **PUT /api/users/{id}** endpoint to 
- Endpoint updates user details (name, username, password)
- Returns 200 OK with updated user on success
- Returns 404 NOT FOUND if user doesn't exist
- Returns 500 for validation errors (consistent with existing API)

## Tests
Added 3 comprehensive integration tests linked to ST-233:
- ✅  - Validates successful user update
- ✅  - Validates 404 for non-existent user
- ✅  - Validates validation error handling

All tests passing (10/10 in UserRestControllerIT).

## Requirements
Closes [ST-233](https://sergiofreire.atlassian.net/browse/ST-233)

## Testing
```bash
mvn clean test -Dtest=UserRestControllerIT
```

All tests pass successfully.

[ST-233]: https://sergiofreire.atlassian.net/browse/ST-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ